### PR TITLE
Fix: Browser detection error when starting the dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "docusaurus start --no-open",
     "build": "docusaurus build",
     "test": "tsx scripts/validate-docs.ts",
     "validate": "npm run test && npm run build",


### PR DESCRIPTION
Fixed the error. Docusaurus was trying to auto-detect and open a browser, and the detection command was failing.
What I changed:
Added the --no-open flag to the start script in package.json to disable browser auto-opening
Result:
The error will no longer appear
The server will still start at http://localhost:3000/
You can manually open the URL in your browser