### PR TITLE
Add pronunciation helper for ODE acronym #8

### DIFF
--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -8,6 +8,10 @@ Common questions about ODE installation, usage, and development.
 
 ## General Questions
 
+### How do you pronounce ODE?
+
+ODE is pronounced like "code", without the "C."
+
 ### What is ODE?
 
 Open Data Ensemble (ODE) is a platform for mobile data collection and synchronization. It provides tools for creating forms, collecting data offline, and synchronizing data across devices and servers.

--- a/docs/getting-started/what-is-ode.md
+++ b/docs/getting-started/what-is-ode.md
@@ -4,6 +4,10 @@ sidebar_position: 1
 
 # What is ODE?
 
+:::tip Pronunciation
+ODE is pronounced like "code", without the "C."
+:::
+
 Open Data Ensemble (ODE) is a platform designed to simplify mobile data collection and management. It provides tools and infrastructure for creating forms, collecting data in the field, and synchronizing information across devices and servers.
 
 ## Overview

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,10 @@ sidebar_position: 1
 
 # Open Data Ensemble
 
+:::tip Pronunciation
+ODE is pronounced like "code", without the "C."
+:::
+
 Open Data Ensemble (ODE) is a comprehensive platform for mobile data collection and synchronization. Built for researchers, health professionals, implementers, and developers, ODE provides a robust solution for designing forms, managing data securely, and synchronizing seamlessly across devices, even in offline conditions.
 
 :::info Pre-release Available

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,6 +40,9 @@ export default function Home(): ReactNode {
               The Open Data Ensemble
             </Heading>
             <div className={styles.sectionContent}>
+              <p className={styles.descriptionText} style={{ fontStyle: 'italic', color: 'var(--ifm-color-content-secondary)', marginBottom: '0.5rem' }}>
+                ODE is pronounced like "code", without the "C."
+              </p>
               <p className={styles.descriptionText}>
                 The Open Data Ensemble (ODE) is a comprehensive platform for building sophisticated data collection
                 instruments. It provides a collection of open source technologies and resources that help you build and


### PR DESCRIPTION
# SUMMARY

Adds pronunciation guidance for ODE across key entry points of the documentation. The pronunciation helper appears in the "**What is ODE?**" page, **FAQ**, **homepage**, and **main docs index** to ensure newcomers understand that **ODE** is pronounced like **"code",** without the "**C**."

## Solves
Issue #8 

---

cc

cc @r0ssing 