### PR TITLE
docs: add Formulus legal pages and footer links

### DIFF
--- a/docs/legal/formulus-account-deletion.md
+++ b/docs/legal/formulus-account-deletion.md
@@ -44,7 +44,7 @@ Open Data Ensemble **cannot** delete accounts or server data on third-party or c
 
 If you are unsure which server operator to contact, or you need general guidance about Formulus:
 
-- **Email:** [hello@sapiens-solutions.com](mailto:hello@sapiens-solutions.com)  
+- **Email:** [hello@opendataensemble.org](mailto:hello@opendataensemble.org)  
 - Include: app name (Formulus), your organization or server URL (if known), and whether you need **local** deletion help or **server** account deletion.
 
 ODE will respond with directions; we do not have access to delete your server-side account without your operator’s involvement.

--- a/docs/legal/formulus-account-deletion.md
+++ b/docs/legal/formulus-account-deletion.md
@@ -1,0 +1,70 @@
+---
+sidebar_position: 3
+title: Formulus account and data deletion
+---
+
+# Formulus — Account and data deletion
+
+**App name:** Formulus  
+**Developer:** Open Data Ensemble  
+**Package name:** `org.opendataensemble.formulus`  
+**Last updated:** 4 June 2026
+
+This page explains how users can delete their data and, where applicable, accounts related to Formulus. It is provided for Google Play and for end-user transparency.
+
+## Important: who operates your account
+
+Formulus **does not create or host end-user accounts on Open Data Ensemble servers**. You sign in with a **username and password** for a **Synkronus server** that your organization (or project) operates. Account creation and server-side deletion are managed by that **server administrator**, not by the Formulus app alone.
+
+## 1. Delete data on your device (local data)
+
+You can remove data stored on your phone or tablet without contacting ODE:
+
+1. **Uninstall Formulus** from your device, or  
+2. Open Android **Settings → Apps → Formulus → Storage → Clear storage** (wording may vary by device).
+
+**What is deleted:** app settings, cached forms, local observations, attachments, and stored login credentials on that device.
+
+**What is not deleted:** data already synchronized to your Synkronus server (see section 2).
+
+**Retention:** Local data is removed when you uninstall or clear storage. ODE does not retain copies on its own servers.
+
+## 2. Delete your server account and synced data
+
+To delete your **login account** and **data on the sync server** (observations, attachments, user record):
+
+1. Contact the **administrator** of the Synkronus server you use (your project lead, IT team, or organization that gave you credentials).  
+2. Ask them to **delete your user account** and any data associated with it on that server, according to their policies.
+
+Open Data Ensemble **cannot** delete accounts or server data on third-party or customer-operated Synkronus instances.
+
+**Retention:** Determined by your server operator’s policies, not by ODE.
+
+## 3. Request help from Open Data Ensemble
+
+If you are unsure which server operator to contact, or you need general guidance about Formulus:
+
+- **Email:** [hello@sapiens-solutions.com](mailto:hello@sapiens-solutions.com)  
+- Include: app name (Formulus), your organization or server URL (if known), and whether you need **local** deletion help or **server** account deletion.
+
+ODE will respond with directions; we do not have access to delete your server-side account without your operator’s involvement.
+
+## 4. Deleting some data without deleting your account
+
+Formulus does **not** currently offer a single in-app control to delete all server-side data while keeping your login account. Partial deletion on the server (e.g. specific observations) is handled by your organization’s processes or server administration tools.
+
+**Local-only partial removal:** clearing app storage (section 1) removes local copies but does not remove data already on the server.
+
+## Summary table
+
+| Data location | How to delete | Who handles it |
+| ------------- | ------------- | -------------- |
+| On your device | Uninstall app or clear app storage | You |
+| On Synkronus server | Request deletion from server administrator | Your organization / server operator |
+| ODE-operated servers | Not applicable for typical deployments | N/A |
+
+## Related documents
+
+- [Formulus privacy policy](./formulus-privacy-policy)
+- [Formulus terms of use](./formulus-terms)
+- [Synkronus documentation](https://opendataensemble.org/docs/reference/synkronus-server)

--- a/docs/legal/formulus-privacy-policy.md
+++ b/docs/legal/formulus-privacy-policy.md
@@ -99,7 +99,7 @@ We may update this policy occasionally. The “Last updated” date at the top w
 
 Questions about this privacy policy:
 
-- **Email:** [hello@sapiens-solutions.com](mailto:hello@sapiens-solutions.com)
+- **Email:** [hello@opendataensemble.org](mailto:hello@opendataensemble.org)
 - **Website:** [opendataensemble.org](https://opendataensemble.org)
 
 ## Technical summary

--- a/docs/legal/formulus-privacy-policy.md
+++ b/docs/legal/formulus-privacy-policy.md
@@ -1,0 +1,110 @@
+---
+sidebar_position: 2
+title: Formulus privacy policy
+---
+
+# Privacy Policy for Formulus
+
+**Effective date:** 12 September 2025  
+**Last updated:** 4 June 2026
+
+## Overview
+
+**Formulus** is a data collection application published by **Open Data Ensemble (ODE)**. It prioritizes user privacy and data ownership. This policy explains how the app handles information.
+
+The canonical source for this policy is also maintained in the [ode repository](https://github.com/OpenDataEnsemble/ode/blob/main/formulus/PRIVACY_POLICY.md).
+
+## Our privacy commitment
+
+**Open Data Ensemble does not collect, store, or have access to your personal data or field observations.** Data you create in Formulus remains under your control. It is stored on your device and, when you choose to sync, on the **Synkronus server you configure**.
+
+## Data collection and storage
+
+### What we do not collect
+
+- Personal information about you as an end user
+- Your observation data or form responses
+- Usage analytics or behavioral data for advertising
+- Device identifiers for cross-app tracking
+- Location data (except what you explicitly capture in forms on your device)
+
+### What stays on your device
+
+The following may be stored locally on your device:
+
+- App settings and configuration
+- Authentication credentials for your sync server (stored using platform secure storage)
+- Cached form specifications
+- Observation data and attachments you create
+- Sync status and version information
+
+### Your data, your server
+
+- Observation data and attachments sync only with endpoints **you** provide
+- You configure the sync server URL in the app
+- ODE has no access to or control over your sync server
+- Your data does not pass through ODE-operated collection servers
+
+## Third-party services
+
+### Google Play Store
+
+If you install Formulus from Google Play, Google may collect information according to [Google’s privacy policy](https://policies.google.com/privacy). That is outside ODE’s control.
+
+You may also obtain Formulus from [F-Droid](https://f-droid.org/) or build from [source](https://github.com/OpenDataEnsemble/ode) if you prefer distribution outside Google Play.
+
+### Your sync server
+
+When you configure a sync endpoint, synchronization occurs directly between the app and that server. The **server operator** (your organization or hosting provider) is responsible for how data is stored and processed on the server.
+
+## Permissions
+
+The Android app may request:
+
+- **Internet** — sync with your configured server
+- **Storage / media** — save observations and attachments locally
+- **Camera** — capture photos when you use photo fields (only when you initiate)
+- **Location** — when forms or features you use request location (only when you initiate)
+- **Notifications** — sync progress and completion status
+
+## Data security
+
+- Local data uses standard Android storage practices
+- Connections to your sync server should use **HTTPS** (recommended and defaulted when entering server URLs)
+- Authentication tokens are stored using secure storage (e.g. React Native Keychain)
+- ODE does not operate a central cloud that receives your field data
+
+## Your rights and control
+
+- **Data ownership** — observation data belongs to you and your organization
+- **Data portability** — data syncs to servers you control
+- **Local deletion** — uninstalling the app or clearing app storage removes local data
+- **Account and server data** — see [Account and data deletion](./formulus-account-deletion)
+
+## Children’s privacy
+
+Formulus is not directed at children. It does not knowingly collect personal information from children under 13 through ODE systems. Use by minors should be under appropriate supervision and according to your organization’s policies.
+
+## Changes to this policy
+
+We may update this policy occasionally. The “Last updated” date at the top will change when we do. Material changes may also be noted in release notes or project documentation.
+
+## Data processing roles
+
+- **ODE** provides the Formulus application software; it does not act as controller of your field data on your Synkronus server
+- **Your sync server operator** is responsible for compliance for data stored on that server
+- **You / your organization** are typically the controller for data you collect using Formulus
+
+## Contact
+
+Questions about this privacy policy:
+
+- **Email:** [hello@sapiens-solutions.com](mailto:hello@sapiens-solutions.com)
+- **Website:** [opendataensemble.org](https://opendataensemble.org)
+
+## Technical summary
+
+- Local storage (e.g. AsyncStorage, device file system)
+- Direct HTTPS connections to user-configured Synkronus endpoints
+- No background transmission of field data to ODE-operated servers
+- Open source: [github.com/OpenDataEnsemble/ode](https://github.com/OpenDataEnsemble/ode)

--- a/docs/legal/formulus-terms.md
+++ b/docs/legal/formulus-terms.md
@@ -1,0 +1,73 @@
+---
+sidebar_position: 4
+title: Formulus terms of use
+---
+
+# Formulus — Terms of use
+
+**Effective date:** 4 June 2026  
+**Last updated:** 4 June 2026
+
+These terms apply to your use of the **Formulus** mobile application distributed by **Open Data Ensemble (“ODE”, “we”, “us”)**. By installing or using Formulus, you agree to these terms. If you do not agree, do not use the app.
+
+## 1. The application
+
+Formulus is client software for offline-first, form-based data collection. It connects to **Synkronus** servers that you or your organization configure. ODE provides the app; it does not operate your field data server unless your organization explicitly uses ODE-hosted infrastructure under a separate agreement.
+
+## 2. Your responsibilities
+
+You agree to:
+
+- Use Formulus lawfully and in line with your organization’s policies
+- Keep your login credentials confidential
+- Configure sync servers you are authorized to use
+- Ensure you have permission to collect and sync any personal or sensitive data required by your project
+- Comply with applicable data protection laws in your jurisdiction
+
+You are responsible for data you collect and for the **Synkronus server operator’s** handling of that data.
+
+## 3. Accounts and authentication
+
+Sign-in uses a **username and password** for the Synkronus server you configure. ODE does not provide in-app registration; accounts are created by your server administrator.
+
+Account and server-side data deletion are described in [Account and data deletion](./formulus-account-deletion).
+
+## 4. Privacy
+
+Our handling of information is described in the [Formulus privacy policy](./formulus-privacy-policy). That policy is incorporated into these terms by reference.
+
+## 5. Open source software
+
+Formulus is part of the open source [Open Data Ensemble project](https://github.com/OpenDataEnsemble/ode), licensed under the [MIT License](./open-source-license) unless otherwise noted for bundled components. Source code is available on GitHub; use of the source is subject to the license and separate development terms.
+
+## 6. Disclaimers
+
+Formulus is provided **“as is”** and **“as available”**, without warranties of any kind, express or implied, including merchantability, fitness for a particular purpose, and non-infringement, to the extent permitted by law.
+
+We do not warrant uninterrupted operation, error-free sync, or compatibility with every device or server configuration.
+
+## 7. Limitation of liability
+
+To the maximum extent permitted by law, ODE and its contributors are not liable for indirect, incidental, special, consequential, or punitive damages, or for loss of data, profits, or business arising from your use of Formulus or your sync server.
+
+Your sole remedy for dissatisfaction with the app is to stop using it and uninstall it.
+
+## 8. Third-party services
+
+- **Google Play** — if you install from Play, Google’s terms and policies apply to the store and its services.  
+- **F-Droid** — if you install from F-Droid, that distribution channel has its own policies.  
+- **Your Synkronus server** — operated by you or a third party; not controlled by ODE.
+
+## 9. Changes
+
+We may update these terms. The “Last updated” date will change when we do. Continued use after changes constitutes acceptance of the updated terms where permitted by law.
+
+## 10. Governing law and disputes
+
+These terms are governed by the laws applicable to Open Data Ensemble’s place of establishment, without regard to conflict-of-law rules. Courts in that jurisdiction may have exclusive jurisdiction over disputes arising from these terms, unless mandatory consumer protection laws in your country require otherwise.
+
+## 11. Contact
+
+- **Email:** [hello@sapiens-solutions.com](mailto:hello@sapiens-solutions.com)  
+- **Website:** [opendataensemble.org](https://opendataensemble.org)  
+- **Legal index:** [Legal information](./index)

--- a/docs/legal/formulus-terms.md
+++ b/docs/legal/formulus-terms.md
@@ -68,6 +68,6 @@ These terms are governed by the laws applicable to Open Data Ensemble’s place 
 
 ## 11. Contact
 
-- **Email:** [hello@sapiens-solutions.com](mailto:hello@sapiens-solutions.com)  
+- **Email:** [hello@opendataensemble.org](mailto:hello@opendataensemble.org)  
 - **Website:** [opendataensemble.org](https://opendataensemble.org)  
 - **Legal index:** [Legal information](./index)

--- a/docs/legal/index.md
+++ b/docs/legal/index.md
@@ -1,0 +1,29 @@
+---
+sidebar_position: 1
+title: Legal information
+---
+
+# Legal information
+
+Public pages for **Formulus** on Google Play, F-Droid, and the Open Data Ensemble website.
+
+## Formulus (mobile app)
+
+| Document | URL |
+| -------- | --- |
+| [Privacy policy](./formulus-privacy-policy) | `https://opendataensemble.org/docs/legal/formulus-privacy-policy` |
+| [Account and data deletion](./formulus-account-deletion) | `https://opendataensemble.org/docs/legal/formulus-account-deletion` |
+| [Terms of use](./formulus-terms) | `https://opendataensemble.org/docs/legal/formulus-terms` |
+
+## Open source software
+
+| Document | URL |
+| -------- | --- |
+| [Open source license (MIT)](./open-source-license) | `https://opendataensemble.org/docs/legal/open-source-license` |
+
+Source code: [OpenDataEnsemble/ode on GitHub](https://github.com/OpenDataEnsemble/ode).
+
+## Contact
+
+- **Email:** [hello@sapiens-solutions.com](mailto:hello@sapiens-solutions.com)
+- **Website:** [opendataensemble.org](https://opendataensemble.org)

--- a/docs/legal/index.md
+++ b/docs/legal/index.md
@@ -25,5 +25,5 @@ Source code: [OpenDataEnsemble/ode on GitHub](https://github.com/OpenDataEnsembl
 
 ## Contact
 
-- **Email:** [hello@sapiens-solutions.com](mailto:hello@sapiens-solutions.com)
+- **Email:** [hello@opendataensemble.org](mailto:hello@opendataensemble.org)
 - **Website:** [opendataensemble.org](https://opendataensemble.org)

--- a/docs/legal/open-source-license.md
+++ b/docs/legal/open-source-license.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 5
+title: Open source license
+---
+
+# Open source license (MIT)
+
+The **Open Data Ensemble (ODE)** monorepo, including **Formulus**, **Synkronus**, **Formplayer**, and related components, is released under the **MIT License** unless a subdirectory specifies a different license.
+
+## Copyright
+
+Copyright (c) 2026 Open Data Ensemble
+
+## License text
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## Canonical source
+
+The license file in the repository:
+
+[github.com/OpenDataEnsemble/ode/blob/main/LICENSE](https://github.com/OpenDataEnsemble/ode/blob/main/LICENSE)
+
+## Third-party components
+
+Formulus and other ODE apps include open source dependencies (e.g. React Native, libraries from npm). Those components are subject to their own licenses, typically included in application notices or dependency metadata.
+
+## App store terms
+
+Use of Formulus from **Google Play** or **F-Droid** is also subject to:
+
+- [Formulus terms of use](./formulus-terms) (app use)
+- The store operator’s terms (Google, F-Droid)
+
+This MIT license governs the **source code**; it does not replace store distribution agreements.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,6 +179,27 @@ const config: Config = {
           ],
         },
         {
+          title: 'Legal',
+          items: [
+            {
+              label: 'Formulus privacy policy',
+              to: '/docs/legal/formulus-privacy-policy',
+            },
+            {
+              label: 'Account & data deletion',
+              to: '/docs/legal/formulus-account-deletion',
+            },
+            {
+              label: 'Formulus terms of use',
+              to: '/docs/legal/formulus-terms',
+            },
+            {
+              label: 'Open source license (MIT)',
+              to: '/docs/legal/open-source-license',
+            },
+          ],
+        },
+        {
           title: 'Contact',
           items: [
             {

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -209,6 +209,7 @@ const sidebars: SidebarsConfig = {
         'community/contribute/code-of-conduct',
       ],
     },
+
   ],
 };
 


### PR DESCRIPTION
## Description

Adds public **Formulus legal pages** on opendataensemble.org for Google Play and general transparency: privacy policy, account/data deletion, terms of use, and MIT license summary.

## Changes

- New docs under `docs/legal/` (privacy, account deletion, terms, open-source license, index)
- **Footer links only** — no sidebar entries
- Content aligned with `formulus/PRIVACY_POLICY.md` and Synkronus-hosted accounts (no ODE-hosted user accounts)

## Play Console URLs (after deploy)

| Use | URL |
|-----|-----|
| Privacy policy | `https://opendataensemble.org/docs/legal/formulus-privacy-policy` |
| Delete account URL | `https://opendataensemble.org/docs/legal/formulus-account-deletion` |
